### PR TITLE
fix(menubar): make panel presentation reliable

### DIFF
--- a/apps/menubar/Checks/MenuBarChecks.swift
+++ b/apps/menubar/Checks/MenuBarChecks.swift
@@ -125,6 +125,49 @@ struct MenuBarChecks {
         let launchPresentationCount = await presentationCountAfterLaunch()
         try require(launchPresentationCount == 1, "launching OpenSurge must show the menu bar panel")
 
+        let applicationStateChangeCount = await stateChangeCountAfterLifecycleEvents()
+        try require(
+            applicationStateChangeCount == 2,
+            "AppKit activation and update events must resume pending panel presentation"
+        )
+
+        try require(
+            panelPresentationAction(applicationActive: false) == .activateApplication,
+            "panel presentation must wait for real application activation"
+        )
+        try require(
+            panelPresentationAction(anchorVisible: false) == .waitForAnchor,
+            "panel presentation must wait for a visible status-item anchor"
+        )
+        try require(
+            panelPresentationAction(popoverShown: false) == .showPopover,
+            "ready panel presentation must show the popover"
+        )
+        try require(
+            panelPresentationAction(panelWindowAvailable: false) == .resetPopover,
+            "a logical popover without a real window must be reset"
+        )
+        try require(
+            panelPresentationAction(panelWindowKey: false) == .makePanelKey,
+            "the popover window must become key before presentation completes"
+        )
+        try require(
+            panelPresentationAction() == .complete,
+            "panel presentation must complete only with an active key window"
+        )
+        try require(
+            menuBarPanelPresentationAction(
+                presentationPending: true,
+                popoverResetInProgress: true,
+                applicationActive: true,
+                anchorVisible: true,
+                popoverShown: true,
+                panelWindowAvailable: false,
+                panelWindowKey: false
+            ) == .none,
+            "popover close recovery must not be re-entered while its animation is pending"
+        )
+
         var fallbackOpened = false
         let launcher = WebGUIURLLauncher(
             workspaceOpen: { _ in false },
@@ -165,9 +208,42 @@ private func presentationCountAfterLaunch() async -> Int {
 }
 
 @MainActor
+private func stateChangeCountAfterLifecycleEvents() -> Int {
+    let panelPresenter = CheckMenuBarPresenter()
+    let appDelegate = OpenSurgeAppDelegate(presenter: panelPresenter)
+    appDelegate.applicationDidBecomeActive(
+        Notification(name: NSApplication.didBecomeActiveNotification)
+    )
+    appDelegate.applicationDidUpdate(
+        Notification(name: NSApplication.didUpdateNotification)
+    )
+    return panelPresenter.stateChangeCount
+}
+
+@MainActor
 private final class CheckMenuBarPresenter: MenuBarPresenting {
     var presentationCount = 0
+    var stateChangeCount = 0
     func showPanel() { presentationCount += 1 }
+    func applicationStateDidChange() { stateChangeCount += 1 }
+}
+
+private func panelPresentationAction(
+    applicationActive: Bool = true,
+    anchorVisible: Bool = true,
+    popoverShown: Bool = true,
+    panelWindowAvailable: Bool = true,
+    panelWindowKey: Bool = true
+) -> MenuBarPanelPresentationAction {
+    menuBarPanelPresentationAction(
+        presentationPending: true,
+        popoverResetInProgress: false,
+        applicationActive: applicationActive,
+        anchorVisible: anchorVisible,
+        popoverShown: popoverShown,
+        panelWindowAvailable: panelWindowAvailable,
+        panelWindowKey: panelWindowKey
+    )
 }
 
 private func requestBody(_ request: URLRequest) -> Data {

--- a/apps/menubar/Checks/MenuBarChecks.swift
+++ b/apps/menubar/Checks/MenuBarChecks.swift
@@ -127,13 +127,8 @@ struct MenuBarChecks {
 
         let applicationStateChangeCount = await stateChangeCountAfterLifecycleEvents()
         try require(
-            applicationStateChangeCount == 2,
-            "AppKit activation and update events must resume pending panel presentation"
-        )
-
-        try require(
-            panelPresentationAction(applicationActive: false) == .activateApplication,
-            "panel presentation must wait for real application activation"
+            applicationStateChangeCount == 1,
+            "AppKit activation must enhance a visible panel without update-event churn"
         )
         try require(
             panelPresentationAction(anchorVisible: false) == .waitForAnchor,
@@ -154,29 +149,22 @@ struct MenuBarChecks {
             panelPresentationAction(
                 panelWindowAvailable: false,
                 popoverWindowWaitExpired: true
-            ) == .resetPopover,
-            "a logical popover still missing its window after the grace interval must be reset"
-        )
-        try require(
-            panelPresentationAction(panelWindowKey: false) == .makePanelKey,
-            "the popover window must become key before presentation completes"
+            ) == .replacePopover,
+            "a logical popover still missing its window after the grace interval must be replaced"
         )
         try require(
             panelPresentationAction() == .complete,
-            "panel presentation must complete only with an active key window"
+            "a real popover window must complete presentation without waiting for activation or key status"
         )
         try require(
             menuBarPanelPresentationAction(
-                presentationPending: true,
-                popoverResetInProgress: true,
-                applicationActive: true,
+                presentationPending: false,
                 anchorVisible: true,
                 popoverShown: true,
                 panelWindowAvailable: false,
-                popoverWindowWaitExpired: true,
-                panelWindowKey: false
+                popoverWindowWaitExpired: true
             ) == .none,
-            "popover close recovery must not be re-entered while its animation is pending"
+            "a completed or abandoned presentation must not keep advancing"
         )
         try require(
             MenuBarPanelRetryPolicy.delay(after: 0) == 0.05
@@ -188,6 +176,21 @@ struct MenuBarChecks {
             MenuBarPanelRetryPolicy.presentationWindow
                 > MenuBarPanelRetryPolicy.popoverWindowGrace,
             "the bounded startup retry window must allow at least one failed popover recovery"
+        )
+        try require(
+            menuBarPopoverBehavior(applicationActive: false) == .applicationDefined
+                && menuBarPopoverBehavior(applicationActive: true) == .transient,
+            "an inactive app must own popover dismissal until activation succeeds"
+        )
+        try require(
+            !menuBarStatusItemNeedsRefresh(
+                renderedIndicator: .running,
+                nextIndicator: .running
+            ) && menuBarStatusItemNeedsRefresh(
+                renderedIndicator: .running,
+                nextIndicator: .degraded
+            ),
+            "status polling must redraw the menu bar icon only when its indicator changes"
         )
 
         var fallbackOpened = false
@@ -236,9 +239,6 @@ private func stateChangeCountAfterLifecycleEvents() -> Int {
     appDelegate.applicationDidBecomeActive(
         Notification(name: NSApplication.didBecomeActiveNotification)
     )
-    appDelegate.applicationDidUpdate(
-        Notification(name: NSApplication.didUpdateNotification)
-    )
     return panelPresenter.stateChangeCount
 }
 
@@ -247,26 +247,21 @@ private final class CheckMenuBarPresenter: MenuBarPresenting {
     var presentationCount = 0
     var stateChangeCount = 0
     func showPanel() { presentationCount += 1 }
-    func applicationStateDidChange() { stateChangeCount += 1 }
+    func applicationDidBecomeActive() { stateChangeCount += 1 }
 }
 
 private func panelPresentationAction(
-    applicationActive: Bool = true,
     anchorVisible: Bool = true,
     popoverShown: Bool = true,
     panelWindowAvailable: Bool = true,
-    popoverWindowWaitExpired: Bool = true,
-    panelWindowKey: Bool = true
+    popoverWindowWaitExpired: Bool = true
 ) -> MenuBarPanelPresentationAction {
     menuBarPanelPresentationAction(
         presentationPending: true,
-        popoverResetInProgress: false,
-        applicationActive: applicationActive,
         anchorVisible: anchorVisible,
         popoverShown: popoverShown,
         panelWindowAvailable: panelWindowAvailable,
-        popoverWindowWaitExpired: popoverWindowWaitExpired,
-        panelWindowKey: panelWindowKey
+        popoverWindowWaitExpired: popoverWindowWaitExpired
     )
 }
 

--- a/apps/menubar/Checks/MenuBarChecks.swift
+++ b/apps/menubar/Checks/MenuBarChecks.swift
@@ -144,8 +144,18 @@ struct MenuBarChecks {
             "ready panel presentation must show the popover"
         )
         try require(
-            panelPresentationAction(panelWindowAvailable: false) == .resetPopover,
-            "a logical popover without a real window must be reset"
+            panelPresentationAction(
+                panelWindowAvailable: false,
+                popoverWindowWaitExpired: false
+            ) == .waitForPanelWindow,
+            "popover animation must receive a grace interval before recovery"
+        )
+        try require(
+            panelPresentationAction(
+                panelWindowAvailable: false,
+                popoverWindowWaitExpired: true
+            ) == .resetPopover,
+            "a logical popover still missing its window after the grace interval must be reset"
         )
         try require(
             panelPresentationAction(panelWindowKey: false) == .makePanelKey,
@@ -163,9 +173,21 @@ struct MenuBarChecks {
                 anchorVisible: true,
                 popoverShown: true,
                 panelWindowAvailable: false,
+                popoverWindowWaitExpired: true,
                 panelWindowKey: false
             ) == .none,
             "popover close recovery must not be re-entered while its animation is pending"
+        )
+        try require(
+            MenuBarPanelRetryPolicy.delay(after: 0) == 0.05
+                && MenuBarPanelRetryPolicy.delay(after: 5) == 0.1
+                && MenuBarPanelRetryPolicy.delay(after: 10) == 0.25,
+            "panel presentation retry policy must back off instead of spinning"
+        )
+        try require(
+            MenuBarPanelRetryPolicy.presentationWindow
+                > MenuBarPanelRetryPolicy.popoverWindowGrace,
+            "the bounded startup retry window must allow at least one failed popover recovery"
         )
 
         var fallbackOpened = false
@@ -233,6 +255,7 @@ private func panelPresentationAction(
     anchorVisible: Bool = true,
     popoverShown: Bool = true,
     panelWindowAvailable: Bool = true,
+    popoverWindowWaitExpired: Bool = true,
     panelWindowKey: Bool = true
 ) -> MenuBarPanelPresentationAction {
     menuBarPanelPresentationAction(
@@ -242,6 +265,7 @@ private func panelPresentationAction(
         anchorVisible: anchorVisible,
         popoverShown: popoverShown,
         panelWindowAvailable: panelWindowAvailable,
+        popoverWindowWaitExpired: popoverWindowWaitExpired,
         panelWindowKey: panelWindowKey
     )
 }

--- a/apps/menubar/Sources/OpenSurgeMenuBar/MenuBarController.swift
+++ b/apps/menubar/Sources/OpenSurgeMenuBar/MenuBarController.swift
@@ -5,6 +5,39 @@ import SwiftUI
 @MainActor
 protocol MenuBarPresenting: AnyObject {
     func showPanel()
+    func applicationStateDidChange()
+}
+
+extension MenuBarPresenting {
+    func applicationStateDidChange() {}
+}
+
+enum MenuBarPanelPresentationAction: Equatable {
+    case none
+    case activateApplication
+    case waitForAnchor
+    case showPopover
+    case resetPopover
+    case makePanelKey
+    case complete
+}
+
+func menuBarPanelPresentationAction(
+    presentationPending: Bool,
+    popoverResetInProgress: Bool,
+    applicationActive: Bool,
+    anchorVisible: Bool,
+    popoverShown: Bool,
+    panelWindowAvailable: Bool,
+    panelWindowKey: Bool
+) -> MenuBarPanelPresentationAction {
+    guard presentationPending, !popoverResetInProgress else { return .none }
+    guard applicationActive else { return .activateApplication }
+    guard anchorVisible else { return .waitForAnchor }
+    guard popoverShown else { return .showPopover }
+    guard panelWindowAvailable else { return .resetPopover }
+    guard panelWindowKey else { return .makePanelKey }
+    return .complete
 }
 
 @MainActor
@@ -28,9 +61,15 @@ final class OpenSurgeAppDelegate: NSObject, NSApplicationDelegate {
         // Every process launch opens the same panel as the menu bar icon.
         // This also makes the "登录时显示" setting literal: login-item
         // launches present the panel instead of starting silently.
-        DispatchQueue.main.async { [weak self] in
-            self?.presenter?.showPanel()
-        }
+        presenter?.showPanel()
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        presenter?.applicationStateDidChange()
+    }
+
+    func applicationDidUpdate(_ notification: Notification) {
+        presenter?.applicationStateDidChange()
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
@@ -45,6 +84,9 @@ final class MenuBarController: NSObject, MenuBarPresenting {
     private let statusItem: NSStatusItem
     private let popover = NSPopover()
     private var modelObservation: AnyCancellable?
+    private var presentationPending = false
+    private var isResettingFailedPopover = false
+    private var failedPopoverRecoveryCount = 0
 
     init(model: StatusModel) {
         self.model = model
@@ -56,6 +98,7 @@ final class MenuBarController: NSObject, MenuBarPresenting {
         popover.contentViewController = contentController
         popover.behavior = .transient
         popover.animates = true
+        popover.delegate = self
 
         if let button = statusItem.button {
             button.target = self
@@ -71,18 +114,84 @@ final class MenuBarController: NSObject, MenuBarPresenting {
     }
 
     func showPanel() {
-        guard let button = statusItem.button else { return }
-        NSApplication.shared.activate(ignoringOtherApps: true)
-        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        presentationPending = true
+        failedPopoverRecoveryCount = 0
+        advancePanelPresentation()
+    }
+
+    func applicationStateDidChange() {
+        advancePanelPresentation()
     }
 
     @objc
     private func togglePanel(_ sender: Any?) {
         if popover.isShown {
+            cancelPendingPresentation()
             popover.performClose(sender)
         } else {
             showPanel()
         }
+    }
+
+    private func advancePanelPresentation() {
+        guard presentationPending else { return }
+        let button = statusItem.button
+        let panelWindow = popover.contentViewController?.view.window
+        let action = menuBarPanelPresentationAction(
+            presentationPending: presentationPending,
+            popoverResetInProgress: isResettingFailedPopover,
+            applicationActive: NSApplication.shared.isActive,
+            anchorVisible: statusItem.isVisible
+                && button?.window?.isVisible == true
+                && button?.isHiddenOrHasHiddenAncestor == false,
+            popoverShown: popover.isShown,
+            panelWindowAvailable: panelWindow != nil,
+            panelWindowKey: panelWindow?.isKeyWindow == true
+        )
+
+        switch action {
+        case .none, .waitForAnchor:
+            return
+        case .activateApplication:
+            // Opening the App and clicking its status item are explicit user
+            // requests to focus this LSUIElement panel. The cooperative
+            // activate() API is not guaranteed to activate, so use the
+            // macOS 13-compatible forced activation path here.
+            NSApplication.shared.activate(ignoringOtherApps: true)
+        case .showPopover:
+            guard let button else { return }
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        case .resetPopover:
+            recoverFromMissingPopoverWindow()
+        case .makePanelKey:
+            panelWindow?.makeKey()
+            if panelWindow?.isKeyWindow == true {
+                completePanelPresentation()
+            }
+        case .complete:
+            completePanelPresentation()
+        }
+    }
+
+    private func recoverFromMissingPopoverWindow() {
+        guard failedPopoverRecoveryCount < 3 else {
+            return
+        }
+        failedPopoverRecoveryCount += 1
+        isResettingFailedPopover = true
+        popover.close()
+    }
+
+    private func completePanelPresentation() {
+        presentationPending = false
+        failedPopoverRecoveryCount = 0
+        statusItem.button?.highlight(true)
+    }
+
+    private func cancelPendingPresentation() {
+        presentationPending = false
+        failedPopoverRecoveryCount = 0
+        statusItem.button?.highlight(false)
     }
 
     private func updateStatusItem() {
@@ -93,5 +202,21 @@ final class MenuBarController: NSObject, MenuBarPresenting {
         button.alphaValue = indicator.menuBarIconOpacity
         button.toolTip = indicator.accessibilityLabel
         button.setAccessibilityLabel(indicator.accessibilityLabel)
+    }
+}
+
+extension MenuBarController: NSPopoverDelegate {
+    func popoverDidShow(_ notification: Notification) {
+        advancePanelPresentation()
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        if isResettingFailedPopover {
+            isResettingFailedPopover = false
+            statusItem.button?.highlight(false)
+            advancePanelPresentation()
+            return
+        }
+        cancelPendingPresentation()
     }
 }

--- a/apps/menubar/Sources/OpenSurgeMenuBar/MenuBarController.swift
+++ b/apps/menubar/Sources/OpenSurgeMenuBar/MenuBarController.swift
@@ -17,9 +17,27 @@ enum MenuBarPanelPresentationAction: Equatable {
     case activateApplication
     case waitForAnchor
     case showPopover
+    case waitForPanelWindow
     case resetPopover
     case makePanelKey
     case complete
+}
+
+enum MenuBarPanelRetryPolicy {
+    static let presentationWindow: TimeInterval = 8
+    static let popoverWindowGrace: TimeInterval = 1
+    static let popoverResetGrace: TimeInterval = 0.25
+
+    static func delay(after attempt: Int) -> TimeInterval {
+        switch attempt {
+        case ..<5:
+            return 0.05
+        case ..<10:
+            return 0.1
+        default:
+            return 0.25
+        }
+    }
 }
 
 func menuBarPanelPresentationAction(
@@ -29,13 +47,16 @@ func menuBarPanelPresentationAction(
     anchorVisible: Bool,
     popoverShown: Bool,
     panelWindowAvailable: Bool,
+    popoverWindowWaitExpired: Bool,
     panelWindowKey: Bool
 ) -> MenuBarPanelPresentationAction {
     guard presentationPending, !popoverResetInProgress else { return .none }
     guard applicationActive else { return .activateApplication }
     guard anchorVisible else { return .waitForAnchor }
     guard popoverShown else { return .showPopover }
-    guard panelWindowAvailable else { return .resetPopover }
+    guard panelWindowAvailable else {
+        return popoverWindowWaitExpired ? .resetPopover : .waitForPanelWindow
+    }
     guard panelWindowKey else { return .makePanelKey }
     return .complete
 }
@@ -82,23 +103,25 @@ final class OpenSurgeAppDelegate: NSObject, NSApplicationDelegate {
 final class MenuBarController: NSObject, MenuBarPresenting {
     private let model: StatusModel
     private let statusItem: NSStatusItem
-    private let popover = NSPopover()
+    private var popover = NSPopover()
     private var modelObservation: AnyCancellable?
     private var presentationPending = false
     private var isResettingFailedPopover = false
-    private var failedPopoverRecoveryCount = 0
+    private var presentationRetryDeadline: Date?
+    private var presentationRetryAttempt = 0
+    private var presentationRetryScheduled = false
+    private var popoverWindowDeadline: Date?
+    private var popoverResetFallbackScheduled = false
 
     init(model: StatusModel) {
         self.model = model
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         super.init()
 
-        let contentController = NSHostingController(rootView: MenuContentView(model: model))
-        contentController.sizingOptions = [.preferredContentSize]
-        popover.contentViewController = contentController
-        popover.behavior = .transient
-        popover.animates = true
-        popover.delegate = self
+        configurePopover(
+            popover,
+            contentController: makePanelContentController()
+        )
 
         if let button = statusItem.button {
             button.target = self
@@ -115,7 +138,10 @@ final class MenuBarController: NSObject, MenuBarPresenting {
 
     func showPanel() {
         presentationPending = true
-        failedPopoverRecoveryCount = 0
+        presentationRetryDeadline = Date().addingTimeInterval(
+            MenuBarPanelRetryPolicy.presentationWindow
+        )
+        presentationRetryAttempt = 0
         advancePanelPresentation()
     }
 
@@ -125,7 +151,8 @@ final class MenuBarController: NSObject, MenuBarPresenting {
 
     @objc
     private func togglePanel(_ sender: Any?) {
-        if popover.isShown {
+        if popover.isShown,
+           popover.contentViewController?.view.window != nil {
             cancelPendingPresentation()
             popover.performClose(sender)
         } else {
@@ -134,7 +161,9 @@ final class MenuBarController: NSObject, MenuBarPresenting {
     }
 
     private func advancePanelPresentation() {
+        cancelScheduledPresentationRetry()
         guard presentationPending else { return }
+        let now = Date()
         let button = statusItem.button
         let panelWindow = popover.contentViewController?.view.window
         let action = menuBarPanelPresentationAction(
@@ -143,54 +172,192 @@ final class MenuBarController: NSObject, MenuBarPresenting {
             applicationActive: NSApplication.shared.isActive,
             anchorVisible: statusItem.isVisible
                 && button?.window?.isVisible == true
+                && button?.window?.screen != nil
                 && button?.isHiddenOrHasHiddenAncestor == false,
             popoverShown: popover.isShown,
             panelWindowAvailable: panelWindow != nil,
+            popoverWindowWaitExpired: popoverWindowDeadline.map { now >= $0 } ?? true,
             panelWindowKey: panelWindow?.isKeyWindow == true
         )
 
         switch action {
-        case .none, .waitForAnchor:
+        case .none:
             return
+        case .waitForAnchor:
+            schedulePresentationRetry()
         case .activateApplication:
-            // Opening the App and clicking its status item are explicit user
-            // requests to focus this LSUIElement panel. The cooperative
-            // activate() API is not guaranteed to activate, so use the
-            // macOS 13-compatible forced activation path here.
-            NSApplication.shared.activate(ignoringOtherApps: true)
+            requestApplicationActivation()
+            schedulePresentationRetry()
         case .showPopover:
-            guard let button else { return }
+            guard let button else {
+                schedulePresentationRetry()
+                return
+            }
+            let windowDeadline = Date().addingTimeInterval(
+                MenuBarPanelRetryPolicy.popoverWindowGrace
+            )
+            popoverWindowDeadline = windowDeadline
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            schedulePresentationRetry(notBefore: windowDeadline)
+        case .waitForPanelWindow:
+            schedulePresentationRetry(notBefore: popoverWindowDeadline)
         case .resetPopover:
             recoverFromMissingPopoverWindow()
         case .makePanelKey:
             panelWindow?.makeKey()
             if panelWindow?.isKeyWindow == true {
                 completePanelPresentation()
+            } else {
+                schedulePresentationRetry()
             }
         case .complete:
             completePanelPresentation()
         }
     }
 
+    private func requestApplicationActivation() {
+        // Opening the app and clicking its status item are explicit requests
+        // to focus this LSUIElement panel. macOS 14 replaced forced activation
+        // with cooperative activation, whose result can arrive later.
+        if #available(macOS 14.0, *) {
+            NSApplication.shared.activate()
+        } else {
+            NSApplication.shared.activate(ignoringOtherApps: true)
+        }
+    }
+
     private func recoverFromMissingPopoverWindow() {
-        guard failedPopoverRecoveryCount < 3 else {
+        guard !isResettingFailedPopover else { return }
+        isResettingFailedPopover = true
+        popoverWindowDeadline = nil
+
+        // A failed show can leave NSPopover logically shown without ever
+        // creating a window. Replace that invalid presentation object instead
+        // of depending on a didClose callback that might never arrive.
+        let failedPopover = popover
+        failedPopover.delegate = nil
+        failedPopover.close()
+        let replacement = NSPopover()
+        configurePopover(
+            replacement,
+            contentController: makePanelContentController()
+        )
+        popover = replacement
+        schedulePopoverResetFallback()
+    }
+
+    private func makePanelContentController() -> NSHostingController<MenuContentView> {
+        let contentController = NSHostingController(
+            rootView: MenuContentView(model: model)
+        )
+        contentController.sizingOptions = [.preferredContentSize]
+        return contentController
+    }
+
+    private func configurePopover(
+        _ candidate: NSPopover,
+        contentController: NSViewController
+    ) {
+        candidate.contentViewController = contentController
+        candidate.behavior = .transient
+        candidate.animates = true
+        candidate.delegate = self
+    }
+
+    private func schedulePresentationRetry(notBefore: Date? = nil) {
+        guard presentationPending,
+              !isResettingFailedPopover,
+              !presentationRetryScheduled,
+              let retryDeadline = presentationRetryDeadline else {
             return
         }
-        failedPopoverRecoveryCount += 1
-        isResettingFailedPopover = true
-        popover.close()
+
+        let now = Date()
+        let remaining = retryDeadline.timeIntervalSince(now)
+        guard remaining > 0 else { return }
+
+        var delay = MenuBarPanelRetryPolicy.delay(after: presentationRetryAttempt)
+        if let notBefore {
+            delay = max(delay, notBefore.timeIntervalSince(now))
+        }
+        delay = max(0.01, min(delay, remaining))
+
+        presentationRetryScheduled = true
+        presentationRetryAttempt += 1
+        perform(
+            #selector(retryPanelPresentation),
+            with: nil,
+            afterDelay: delay,
+            inModes: [.common]
+        )
+    }
+
+    @objc
+    private func retryPanelPresentation() {
+        presentationRetryScheduled = false
+        advancePanelPresentation()
+    }
+
+    private func cancelScheduledPresentationRetry() {
+        guard presentationRetryScheduled else { return }
+        NSObject.cancelPreviousPerformRequests(
+            withTarget: self,
+            selector: #selector(retryPanelPresentation),
+            object: nil
+        )
+        presentationRetryScheduled = false
+    }
+
+    private func schedulePopoverResetFallback() {
+        cancelScheduledPopoverResetFallback()
+        popoverResetFallbackScheduled = true
+        perform(
+            #selector(finishPopoverResetAfterTimeout),
+            with: nil,
+            afterDelay: MenuBarPanelRetryPolicy.popoverResetGrace,
+            inModes: [.common]
+        )
+    }
+
+    @objc
+    private func finishPopoverResetAfterTimeout() {
+        popoverResetFallbackScheduled = false
+        finishPopoverReset()
+    }
+
+    private func cancelScheduledPopoverResetFallback() {
+        guard popoverResetFallbackScheduled else { return }
+        NSObject.cancelPreviousPerformRequests(
+            withTarget: self,
+            selector: #selector(finishPopoverResetAfterTimeout),
+            object: nil
+        )
+        popoverResetFallbackScheduled = false
+    }
+
+    private func finishPopoverReset() {
+        guard isResettingFailedPopover else { return }
+        cancelScheduledPopoverResetFallback()
+        isResettingFailedPopover = false
+        statusItem.button?.highlight(false)
+        schedulePresentationRetry()
     }
 
     private func completePanelPresentation() {
         presentationPending = false
-        failedPopoverRecoveryCount = 0
+        presentationRetryDeadline = nil
+        presentationRetryAttempt = 0
+        popoverWindowDeadline = nil
+        cancelScheduledPresentationRetry()
         statusItem.button?.highlight(true)
     }
 
     private func cancelPendingPresentation() {
         presentationPending = false
-        failedPopoverRecoveryCount = 0
+        presentationRetryDeadline = nil
+        presentationRetryAttempt = 0
+        popoverWindowDeadline = nil
+        cancelScheduledPresentationRetry()
         statusItem.button?.highlight(false)
     }
 
@@ -207,14 +374,13 @@ final class MenuBarController: NSObject, MenuBarPresenting {
 
 extension MenuBarController: NSPopoverDelegate {
     func popoverDidShow(_ notification: Notification) {
+        popoverWindowDeadline = nil
         advancePanelPresentation()
     }
 
     func popoverDidClose(_ notification: Notification) {
         if isResettingFailedPopover {
-            isResettingFailedPopover = false
-            statusItem.button?.highlight(false)
-            advancePanelPresentation()
+            finishPopoverReset()
             return
         }
         cancelPendingPresentation()

--- a/apps/menubar/Sources/OpenSurgeMenuBar/MenuBarController.swift
+++ b/apps/menubar/Sources/OpenSurgeMenuBar/MenuBarController.swift
@@ -463,7 +463,6 @@ final class MenuBarController: NSObject, MenuBarPresenting {
     private func applyStatusItemPresentedState() {
         guard let button = statusItem.button else { return }
         button.state = panelPresented ? .on : .off
-        button.highlight(panelPresented)
     }
 
     private func updateStatusItem() {

--- a/apps/menubar/Sources/OpenSurgeMenuBar/MenuBarController.swift
+++ b/apps/menubar/Sources/OpenSurgeMenuBar/MenuBarController.swift
@@ -5,28 +5,25 @@ import SwiftUI
 @MainActor
 protocol MenuBarPresenting: AnyObject {
     func showPanel()
-    func applicationStateDidChange()
+    func applicationDidBecomeActive()
 }
 
 extension MenuBarPresenting {
-    func applicationStateDidChange() {}
+    func applicationDidBecomeActive() {}
 }
 
 enum MenuBarPanelPresentationAction: Equatable {
     case none
-    case activateApplication
     case waitForAnchor
     case showPopover
     case waitForPanelWindow
-    case resetPopover
-    case makePanelKey
+    case replacePopover
     case complete
 }
 
 enum MenuBarPanelRetryPolicy {
     static let presentationWindow: TimeInterval = 8
     static let popoverWindowGrace: TimeInterval = 1
-    static let popoverResetGrace: TimeInterval = 0.25
 
     static func delay(after attempt: Int) -> TimeInterval {
         switch attempt {
@@ -42,23 +39,29 @@ enum MenuBarPanelRetryPolicy {
 
 func menuBarPanelPresentationAction(
     presentationPending: Bool,
-    popoverResetInProgress: Bool,
-    applicationActive: Bool,
     anchorVisible: Bool,
     popoverShown: Bool,
     panelWindowAvailable: Bool,
-    popoverWindowWaitExpired: Bool,
-    panelWindowKey: Bool
+    popoverWindowWaitExpired: Bool
 ) -> MenuBarPanelPresentationAction {
-    guard presentationPending, !popoverResetInProgress else { return .none }
-    guard applicationActive else { return .activateApplication }
+    guard presentationPending else { return .none }
     guard anchorVisible else { return .waitForAnchor }
     guard popoverShown else { return .showPopover }
     guard panelWindowAvailable else {
-        return popoverWindowWaitExpired ? .resetPopover : .waitForPanelWindow
+        return popoverWindowWaitExpired ? .replacePopover : .waitForPanelWindow
     }
-    guard panelWindowKey else { return .makePanelKey }
     return .complete
+}
+
+func menuBarPopoverBehavior(applicationActive: Bool) -> NSPopover.Behavior {
+    applicationActive ? .transient : .applicationDefined
+}
+
+func menuBarStatusItemNeedsRefresh(
+    renderedIndicator: IndicatorState?,
+    nextIndicator: IndicatorState
+) -> Bool {
+    renderedIndicator != nextIndicator
 }
 
 @MainActor
@@ -86,11 +89,7 @@ final class OpenSurgeAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
-        presenter?.applicationStateDidChange()
-    }
-
-    func applicationDidUpdate(_ notification: Notification) {
-        presenter?.applicationStateDidChange()
+        presenter?.applicationDidBecomeActive()
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
@@ -106,12 +105,15 @@ final class MenuBarController: NSObject, MenuBarPresenting {
     private var popover = NSPopover()
     private var modelObservation: AnyCancellable?
     private var presentationPending = false
-    private var isResettingFailedPopover = false
     private var presentationRetryDeadline: Date?
     private var presentationRetryAttempt = 0
     private var presentationRetryScheduled = false
     private var popoverWindowDeadline: Date?
-    private var popoverResetFallbackScheduled = false
+    private var panelPresented = false
+    private var renderedIndicator: IndicatorState?
+    private var outsideClickMonitor: Any?
+    private var escapeKeyMonitor: Any?
+    private var finalPresentationVerificationScheduled = false
 
     init(model: StatusModel) {
         self.model = model
@@ -127,6 +129,9 @@ final class MenuBarController: NSObject, MenuBarPresenting {
             button.target = self
             button.action = #selector(togglePanel(_:))
             button.sendAction(on: [.leftMouseUp])
+            // NSChangeBackgroundCellMask is imported without a Swift member
+            // name in the macOS 14 SDK used by this project.
+            (button.cell as? NSButtonCell)?.showsStateBy = NSCell.StyleMask(rawValue: 1 << 3)
         }
         updateStatusItem()
         modelObservation = model.objectWillChange.sink { [weak self] _ in
@@ -137,16 +142,19 @@ final class MenuBarController: NSObject, MenuBarPresenting {
     }
 
     func showPanel() {
+        cancelFinalPresentationVerification()
         presentationPending = true
         presentationRetryDeadline = Date().addingTimeInterval(
             MenuBarPanelRetryPolicy.presentationWindow
         )
         presentationRetryAttempt = 0
+        requestApplicationActivation()
         advancePanelPresentation()
     }
 
-    func applicationStateDidChange() {
+    func applicationDidBecomeActive() {
         advancePanelPresentation()
+        promoteVisiblePanelForActiveApplication()
     }
 
     @objc
@@ -168,16 +176,13 @@ final class MenuBarController: NSObject, MenuBarPresenting {
         let panelWindow = popover.contentViewController?.view.window
         let action = menuBarPanelPresentationAction(
             presentationPending: presentationPending,
-            popoverResetInProgress: isResettingFailedPopover,
-            applicationActive: NSApplication.shared.isActive,
             anchorVisible: statusItem.isVisible
                 && button?.window?.isVisible == true
                 && button?.window?.screen != nil
                 && button?.isHiddenOrHasHiddenAncestor == false,
             popoverShown: popover.isShown,
             panelWindowAvailable: panelWindow != nil,
-            popoverWindowWaitExpired: popoverWindowDeadline.map { now >= $0 } ?? true,
-            panelWindowKey: panelWindow?.isKeyWindow == true
+            popoverWindowWaitExpired: popoverWindowDeadline.map { now >= $0 } ?? true
         )
 
         switch action {
@@ -185,14 +190,12 @@ final class MenuBarController: NSObject, MenuBarPresenting {
             return
         case .waitForAnchor:
             schedulePresentationRetry()
-        case .activateApplication:
-            requestApplicationActivation()
-            schedulePresentationRetry()
         case .showPopover:
             guard let button else {
                 schedulePresentationRetry()
                 return
             }
+            preparePopoverForCurrentActivationState()
             let windowDeadline = Date().addingTimeInterval(
                 MenuBarPanelRetryPolicy.popoverWindowGrace
             )
@@ -201,24 +204,17 @@ final class MenuBarController: NSObject, MenuBarPresenting {
             schedulePresentationRetry(notBefore: windowDeadline)
         case .waitForPanelWindow:
             schedulePresentationRetry(notBefore: popoverWindowDeadline)
-        case .resetPopover:
-            recoverFromMissingPopoverWindow()
-        case .makePanelKey:
-            panelWindow?.makeKey()
-            if panelWindow?.isKeyWindow == true {
-                completePanelPresentation()
-            } else {
-                schedulePresentationRetry()
-            }
+        case .replacePopover:
+            replaceFailedPopover()
+            schedulePresentationRetry()
         case .complete:
             completePanelPresentation()
         }
     }
 
     private func requestApplicationActivation() {
-        // Opening the app and clicking its status item are explicit requests
-        // to focus this LSUIElement panel. macOS 14 replaced forced activation
-        // with cooperative activation, whose result can arrive later.
+        // Activation is a best-effort enhancement. Presentation never waits
+        // for this request because cooperative activation may be declined.
         if #available(macOS 14.0, *) {
             NSApplication.shared.activate()
         } else {
@@ -226,10 +222,10 @@ final class MenuBarController: NSObject, MenuBarPresenting {
         }
     }
 
-    private func recoverFromMissingPopoverWindow() {
-        guard !isResettingFailedPopover else { return }
-        isResettingFailedPopover = true
+    private func replaceFailedPopover() {
         popoverWindowDeadline = nil
+        setPanelPresented(false)
+        removeApplicationDefinedDismissMonitors()
 
         // A failed show can leave NSPopover logically shown without ever
         // creating a window. Replace that invalid presentation object instead
@@ -243,12 +239,12 @@ final class MenuBarController: NSObject, MenuBarPresenting {
             contentController: makePanelContentController()
         )
         popover = replacement
-        schedulePopoverResetFallback()
     }
 
-    private func makePanelContentController() -> NSHostingController<MenuContentView> {
+    private func makePanelContentController() -> NSViewController {
         let contentController = NSHostingController(
             rootView: MenuContentView(model: model)
+                .environment(\.controlActiveState, .key)
         )
         contentController.sizingOptions = [.preferredContentSize]
         return contentController
@@ -259,14 +255,65 @@ final class MenuBarController: NSObject, MenuBarPresenting {
         contentController: NSViewController
     ) {
         candidate.contentViewController = contentController
-        candidate.behavior = .transient
+        candidate.behavior = .applicationDefined
         candidate.animates = true
         candidate.delegate = self
     }
 
+    private func preparePopoverForCurrentActivationState() {
+        popover.behavior = menuBarPopoverBehavior(
+            applicationActive: NSApplication.shared.isActive
+        )
+        if popover.behavior == .transient {
+            removeApplicationDefinedDismissMonitors()
+        } else {
+            installApplicationDefinedDismissMonitors()
+        }
+    }
+
+    private func installApplicationDefinedDismissMonitors() {
+        if outsideClickMonitor == nil {
+            outsideClickMonitor = NSEvent.addGlobalMonitorForEvents(
+                matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+            ) { [weak self] _ in
+                DispatchQueue.main.async {
+                    self?.closePanel()
+                }
+            }
+        }
+        if escapeKeyMonitor == nil {
+            escapeKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) {
+                [weak self] event in
+                guard event.keyCode == 53 else { return event }
+                self?.closePanel()
+                return nil
+            }
+        }
+    }
+
+    private func removeApplicationDefinedDismissMonitors() {
+        if let outsideClickMonitor {
+            NSEvent.removeMonitor(outsideClickMonitor)
+            self.outsideClickMonitor = nil
+        }
+        if let escapeKeyMonitor {
+            NSEvent.removeMonitor(escapeKeyMonitor)
+            self.escapeKeyMonitor = nil
+        }
+    }
+
+    private func promoteVisiblePanelForActiveApplication() {
+        guard NSApplication.shared.isActive,
+              let panelWindow = popover.contentViewController?.view.window else {
+            return
+        }
+        panelWindow.makeKey()
+        popover.behavior = .transient
+        removeApplicationDefinedDismissMonitors()
+    }
+
     private func schedulePresentationRetry(notBefore: Date? = nil) {
         guard presentationPending,
-              !isResettingFailedPopover,
               !presentationRetryScheduled,
               let retryDeadline = presentationRetryDeadline else {
             return
@@ -274,7 +321,10 @@ final class MenuBarController: NSObject, MenuBarPresenting {
 
         let now = Date()
         let remaining = retryDeadline.timeIntervalSince(now)
-        guard remaining > 0 else { return }
+        guard remaining > 0 else {
+            finishTimedOutPanelPresentation()
+            return
+        }
 
         var delay = MenuBarPanelRetryPolicy.delay(after: presentationRetryAttempt)
         if let notBefore {
@@ -308,81 +358,145 @@ final class MenuBarController: NSObject, MenuBarPresenting {
         presentationRetryScheduled = false
     }
 
-    private func schedulePopoverResetFallback() {
-        cancelScheduledPopoverResetFallback()
-        popoverResetFallbackScheduled = true
+    private func finishTimedOutPanelPresentation() {
+        let button = statusItem.button
+        let anchorVisible = statusItem.isVisible
+            && button?.window?.isVisible == true
+            && button?.window?.screen != nil
+            && button?.isHiddenOrHasHiddenAncestor == false
+
+        if popover.contentViewController?.view.window != nil {
+            completePanelPresentation()
+            return
+        }
+        if popover.isShown {
+            replaceFailedPopover()
+        }
+
+        clearPendingPresentation()
+        guard anchorVisible, let button else {
+            setPanelPresented(false)
+            return
+        }
+
+        // One final non-blocking attempt avoids leaving a pending state behind.
+        // If AppKit still declines it, the next explicit click starts fresh.
+        preparePopoverForCurrentActivationState()
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        if popover.contentViewController?.view.window != nil {
+            completePanelPresentation()
+        } else {
+            scheduleFinalPresentationVerification()
+        }
+    }
+
+    private func completePanelPresentation() {
+        cancelFinalPresentationVerification()
+        clearPendingPresentation()
+        popoverWindowDeadline = nil
+        setPanelPresented(true)
+        promoteVisiblePanelForActiveApplication()
+    }
+
+    private func cancelPendingPresentation() {
+        cancelFinalPresentationVerification()
+        clearPendingPresentation()
+        popoverWindowDeadline = nil
+        setPanelPresented(false)
+        removeApplicationDefinedDismissMonitors()
+    }
+
+    private func scheduleFinalPresentationVerification() {
+        cancelFinalPresentationVerification()
+        finalPresentationVerificationScheduled = true
         perform(
-            #selector(finishPopoverResetAfterTimeout),
+            #selector(verifyFinalPanelPresentation),
             with: nil,
-            afterDelay: MenuBarPanelRetryPolicy.popoverResetGrace,
+            afterDelay: MenuBarPanelRetryPolicy.popoverWindowGrace,
             inModes: [.common]
         )
     }
 
     @objc
-    private func finishPopoverResetAfterTimeout() {
-        popoverResetFallbackScheduled = false
-        finishPopoverReset()
+    private func verifyFinalPanelPresentation() {
+        finalPresentationVerificationScheduled = false
+        if popover.contentViewController?.view.window != nil {
+            completePanelPresentation()
+            return
+        }
+        if popover.isShown {
+            replaceFailedPopover()
+        }
+        setPanelPresented(false)
+        removeApplicationDefinedDismissMonitors()
     }
 
-    private func cancelScheduledPopoverResetFallback() {
-        guard popoverResetFallbackScheduled else { return }
+    private func cancelFinalPresentationVerification() {
+        guard finalPresentationVerificationScheduled else { return }
         NSObject.cancelPreviousPerformRequests(
             withTarget: self,
-            selector: #selector(finishPopoverResetAfterTimeout),
+            selector: #selector(verifyFinalPanelPresentation),
             object: nil
         )
-        popoverResetFallbackScheduled = false
+        finalPresentationVerificationScheduled = false
     }
 
-    private func finishPopoverReset() {
-        guard isResettingFailedPopover else { return }
-        cancelScheduledPopoverResetFallback()
-        isResettingFailedPopover = false
-        statusItem.button?.highlight(false)
-        schedulePresentationRetry()
-    }
-
-    private func completePanelPresentation() {
+    private func clearPendingPresentation() {
         presentationPending = false
         presentationRetryDeadline = nil
         presentationRetryAttempt = 0
-        popoverWindowDeadline = nil
         cancelScheduledPresentationRetry()
-        statusItem.button?.highlight(true)
     }
 
-    private func cancelPendingPresentation() {
-        presentationPending = false
-        presentationRetryDeadline = nil
-        presentationRetryAttempt = 0
-        popoverWindowDeadline = nil
-        cancelScheduledPresentationRetry()
-        statusItem.button?.highlight(false)
+    private func closePanel() {
+        cancelPendingPresentation()
+        if popover.isShown {
+            popover.performClose(nil)
+        }
+    }
+
+    private func setPanelPresented(_ presented: Bool) {
+        panelPresented = presented
+        applyStatusItemPresentedState()
+    }
+
+    private func applyStatusItemPresentedState() {
+        guard let button = statusItem.button else { return }
+        button.state = panelPresented ? .on : .off
+        button.highlight(panelPresented)
     }
 
     private func updateStatusItem() {
         guard let button = statusItem.button else { return }
         let indicator = model.indicator
+        guard menuBarStatusItemNeedsRefresh(
+            renderedIndicator: renderedIndicator,
+            nextIndicator: indicator
+        ) else {
+            applyStatusItemPresentedState()
+            return
+        }
+        renderedIndicator = indicator
         button.image = openSurgeMenuBarImage(for: indicator)
         button.imagePosition = .imageOnly
         button.alphaValue = indicator.menuBarIconOpacity
         button.toolTip = indicator.accessibilityLabel
         button.setAccessibilityLabel(indicator.accessibilityLabel)
+        applyStatusItemPresentedState()
     }
 }
 
 extension MenuBarController: NSPopoverDelegate {
     func popoverDidShow(_ notification: Notification) {
         popoverWindowDeadline = nil
-        advancePanelPresentation()
+        if popover.contentViewController?.view.window != nil {
+            completePanelPresentation()
+        } else {
+            advancePanelPresentation()
+        }
     }
 
     func popoverDidClose(_ notification: Notification) {
-        if isResettingFailedPopover {
-            finishPopoverReset()
-            return
-        }
         cancelPendingPresentation()
     }
 }

--- a/apps/menubar/Tests/OpenSurgeMenuBarTests/ModelsTests.swift
+++ b/apps/menubar/Tests/OpenSurgeMenuBarTests/ModelsTests.swift
@@ -148,6 +148,54 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(presentationCount, 1)
     }
 
+    @MainActor
+    func testApplicationLifecycleEventsResumePanelPresentation() {
+        let presenter = RecordingMenuBarPresenter()
+        let delegate = OpenSurgeAppDelegate(presenter: presenter)
+
+        delegate.applicationDidBecomeActive(
+            Notification(name: NSApplication.didBecomeActiveNotification)
+        )
+        delegate.applicationDidUpdate(
+            Notification(name: NSApplication.didUpdateNotification)
+        )
+
+        XCTAssertEqual(presenter.stateChangeCount, 2)
+    }
+
+    func testPanelPresentationRequiresActiveApplicationVisibleAnchorAndKeyWindow() {
+        XCTAssertEqual(panelPresentationAction(applicationActive: false), .activateApplication)
+        XCTAssertEqual(panelPresentationAction(anchorVisible: false), .waitForAnchor)
+        XCTAssertEqual(panelPresentationAction(popoverShown: false), .showPopover)
+        XCTAssertEqual(panelPresentationAction(panelWindowAvailable: false), .resetPopover)
+        XCTAssertEqual(panelPresentationAction(panelWindowKey: false), .makePanelKey)
+        XCTAssertEqual(panelPresentationAction(), .complete)
+        XCTAssertEqual(
+            menuBarPanelPresentationAction(
+                presentationPending: false,
+                popoverResetInProgress: false,
+                applicationActive: true,
+                anchorVisible: true,
+                popoverShown: true,
+                panelWindowAvailable: true,
+                panelWindowKey: true
+            ),
+            .none
+        )
+        XCTAssertEqual(
+            menuBarPanelPresentationAction(
+                presentationPending: true,
+                popoverResetInProgress: true,
+                applicationActive: true,
+                anchorVisible: true,
+                popoverShown: true,
+                panelWindowAvailable: false,
+                panelWindowKey: false
+            ),
+            .none
+        )
+    }
+
     private func fixture(gateway: String, recovery: Bool, drift: Bool) -> MenuBarStatus {
         MenuBarStatus(schemaVersion: 1, revision: "r", gateway: gateway, topology: "same_wifi_dhcp",
                       lanIp: "192.168.1.20", dhcp: "running", mihomo: "running", pfAnchor: "loaded",
@@ -160,5 +208,25 @@ final class ModelsTests: XCTestCase {
 @MainActor
 private final class RecordingMenuBarPresenter: MenuBarPresenting {
     var presentationCount = 0
+    var stateChangeCount = 0
     func showPanel() { presentationCount += 1 }
+    func applicationStateDidChange() { stateChangeCount += 1 }
+}
+
+private func panelPresentationAction(
+    applicationActive: Bool = true,
+    anchorVisible: Bool = true,
+    popoverShown: Bool = true,
+    panelWindowAvailable: Bool = true,
+    panelWindowKey: Bool = true
+) -> MenuBarPanelPresentationAction {
+    menuBarPanelPresentationAction(
+        presentationPending: true,
+        popoverResetInProgress: false,
+        applicationActive: applicationActive,
+        anchorVisible: anchorVisible,
+        popoverShown: popoverShown,
+        panelWindowAvailable: panelWindowAvailable,
+        panelWindowKey: panelWindowKey
+    )
 }

--- a/apps/menubar/Tests/OpenSurgeMenuBarTests/ModelsTests.swift
+++ b/apps/menubar/Tests/OpenSurgeMenuBarTests/ModelsTests.swift
@@ -167,7 +167,20 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(panelPresentationAction(applicationActive: false), .activateApplication)
         XCTAssertEqual(panelPresentationAction(anchorVisible: false), .waitForAnchor)
         XCTAssertEqual(panelPresentationAction(popoverShown: false), .showPopover)
-        XCTAssertEqual(panelPresentationAction(panelWindowAvailable: false), .resetPopover)
+        XCTAssertEqual(
+            panelPresentationAction(
+                panelWindowAvailable: false,
+                popoverWindowWaitExpired: false
+            ),
+            .waitForPanelWindow
+        )
+        XCTAssertEqual(
+            panelPresentationAction(
+                panelWindowAvailable: false,
+                popoverWindowWaitExpired: true
+            ),
+            .resetPopover
+        )
         XCTAssertEqual(panelPresentationAction(panelWindowKey: false), .makePanelKey)
         XCTAssertEqual(panelPresentationAction(), .complete)
         XCTAssertEqual(
@@ -178,6 +191,7 @@ final class ModelsTests: XCTestCase {
                 anchorVisible: true,
                 popoverShown: true,
                 panelWindowAvailable: true,
+                popoverWindowWaitExpired: true,
                 panelWindowKey: true
             ),
             .none
@@ -190,9 +204,22 @@ final class ModelsTests: XCTestCase {
                 anchorVisible: true,
                 popoverShown: true,
                 panelWindowAvailable: false,
+                popoverWindowWaitExpired: true,
                 panelWindowKey: false
             ),
             .none
+        )
+    }
+
+    func testPanelPresentationRetriesAreBoundedAndBackOff() {
+        XCTAssertEqual(MenuBarPanelRetryPolicy.delay(after: 0), 0.05)
+        XCTAssertEqual(MenuBarPanelRetryPolicy.delay(after: 4), 0.05)
+        XCTAssertEqual(MenuBarPanelRetryPolicy.delay(after: 5), 0.1)
+        XCTAssertEqual(MenuBarPanelRetryPolicy.delay(after: 9), 0.1)
+        XCTAssertEqual(MenuBarPanelRetryPolicy.delay(after: 10), 0.25)
+        XCTAssertGreaterThan(
+            MenuBarPanelRetryPolicy.presentationWindow,
+            MenuBarPanelRetryPolicy.popoverWindowGrace
         )
     }
 
@@ -218,6 +245,7 @@ private func panelPresentationAction(
     anchorVisible: Bool = true,
     popoverShown: Bool = true,
     panelWindowAvailable: Bool = true,
+    popoverWindowWaitExpired: Bool = true,
     panelWindowKey: Bool = true
 ) -> MenuBarPanelPresentationAction {
     menuBarPanelPresentationAction(
@@ -227,6 +255,7 @@ private func panelPresentationAction(
         anchorVisible: anchorVisible,
         popoverShown: popoverShown,
         panelWindowAvailable: panelWindowAvailable,
+        popoverWindowWaitExpired: popoverWindowWaitExpired,
         panelWindowKey: panelWindowKey
     )
 }

--- a/apps/menubar/Tests/OpenSurgeMenuBarTests/ModelsTests.swift
+++ b/apps/menubar/Tests/OpenSurgeMenuBarTests/ModelsTests.swift
@@ -156,15 +156,11 @@ final class ModelsTests: XCTestCase {
         delegate.applicationDidBecomeActive(
             Notification(name: NSApplication.didBecomeActiveNotification)
         )
-        delegate.applicationDidUpdate(
-            Notification(name: NSApplication.didUpdateNotification)
-        )
 
-        XCTAssertEqual(presenter.stateChangeCount, 2)
+        XCTAssertEqual(presenter.stateChangeCount, 1)
     }
 
-    func testPanelPresentationRequiresActiveApplicationVisibleAnchorAndKeyWindow() {
-        XCTAssertEqual(panelPresentationAction(applicationActive: false), .activateApplication)
+    func testPanelPresentationRequiresVisibleAnchorAndRealWindowButNotActivationOrKeyWindow() {
         XCTAssertEqual(panelPresentationAction(anchorVisible: false), .waitForAnchor)
         XCTAssertEqual(panelPresentationAction(popoverShown: false), .showPopover)
         XCTAssertEqual(
@@ -179,33 +175,16 @@ final class ModelsTests: XCTestCase {
                 panelWindowAvailable: false,
                 popoverWindowWaitExpired: true
             ),
-            .resetPopover
+            .replacePopover
         )
-        XCTAssertEqual(panelPresentationAction(panelWindowKey: false), .makePanelKey)
         XCTAssertEqual(panelPresentationAction(), .complete)
         XCTAssertEqual(
             menuBarPanelPresentationAction(
                 presentationPending: false,
-                popoverResetInProgress: false,
-                applicationActive: true,
                 anchorVisible: true,
                 popoverShown: true,
                 panelWindowAvailable: true,
-                popoverWindowWaitExpired: true,
-                panelWindowKey: true
-            ),
-            .none
-        )
-        XCTAssertEqual(
-            menuBarPanelPresentationAction(
-                presentationPending: true,
-                popoverResetInProgress: true,
-                applicationActive: true,
-                anchorVisible: true,
-                popoverShown: true,
-                panelWindowAvailable: false,
-                popoverWindowWaitExpired: true,
-                panelWindowKey: false
+                popoverWindowWaitExpired: true
             ),
             .none
         )
@@ -223,6 +202,29 @@ final class ModelsTests: XCTestCase {
         )
     }
 
+    func testInactivePopoverOwnsDismissalAndStatusRefreshIsDiffed() {
+        XCTAssertEqual(
+            menuBarPopoverBehavior(applicationActive: false),
+            .applicationDefined
+        )
+        XCTAssertEqual(
+            menuBarPopoverBehavior(applicationActive: true),
+            .transient
+        )
+        XCTAssertFalse(
+            menuBarStatusItemNeedsRefresh(
+                renderedIndicator: .running,
+                nextIndicator: .running
+            )
+        )
+        XCTAssertTrue(
+            menuBarStatusItemNeedsRefresh(
+                renderedIndicator: .running,
+                nextIndicator: .degraded
+            )
+        )
+    }
+
     private func fixture(gateway: String, recovery: Bool, drift: Bool) -> MenuBarStatus {
         MenuBarStatus(schemaVersion: 1, revision: "r", gateway: gateway, topology: "same_wifi_dhcp",
                       lanIp: "192.168.1.20", dhcp: "running", mihomo: "running", pfAnchor: "loaded",
@@ -237,25 +239,20 @@ private final class RecordingMenuBarPresenter: MenuBarPresenting {
     var presentationCount = 0
     var stateChangeCount = 0
     func showPanel() { presentationCount += 1 }
-    func applicationStateDidChange() { stateChangeCount += 1 }
+    func applicationDidBecomeActive() { stateChangeCount += 1 }
 }
 
 private func panelPresentationAction(
-    applicationActive: Bool = true,
     anchorVisible: Bool = true,
     popoverShown: Bool = true,
     panelWindowAvailable: Bool = true,
-    popoverWindowWaitExpired: Bool = true,
-    panelWindowKey: Bool = true
+    popoverWindowWaitExpired: Bool = true
 ) -> MenuBarPanelPresentationAction {
     menuBarPanelPresentationAction(
         presentationPending: true,
-        popoverResetInProgress: false,
-        applicationActive: applicationActive,
         anchorVisible: anchorVisible,
         popoverShown: popoverShown,
         panelWindowAvailable: panelWindowAvailable,
-        popoverWindowWaitExpired: popoverWindowWaitExpired,
-        panelWindowKey: panelWindowKey
+        popoverWindowWaitExpired: popoverWindowWaitExpired
     )
 }

--- a/docs/agent-wiki/wiki/concepts/gui-control-plane.md
+++ b/docs/agent-wiki/wiki/concepts/gui-control-plane.md
@@ -17,16 +17,19 @@ AppKit `NSStatusItem` + `NSPopover` 承载现有 SwiftUI `MenuContentView`。状
 或 Control Service 生命周期动作。每次菜单栏 App 进程启动完成都会主动展开面板，包括
 通过“登录时显示”启动；Finder/Launchpad 的 reopen 事件同样确保面板展开。
 首次启动时，`NSStatusItem` 的按钮可能尚未附着到可见窗口；此时 AppKit 会忽略
-`NSPopover.show`。菜单栏 presenter 必须在状态栏按钮拥有 window 且可见后再展开，并在
-popover window 创建后显式令它成为 key window。后者确保 macOS 26 等较新系统把
-“打开 OpenSurge 面板”的 prominent button 绘制为有焦点的强调色，而不是非活跃窗口样式。
-该流程由 `applicationDidBecomeActive`、`applicationDidUpdate` 与 popover delegate 事件
-推进，并以 common run loop 上的短时、有界退避重试覆盖 macOS 26 首次启动时状态项挂载或
-activation 事件晚到的情况；重试期限耗尽后不得继续轮询，但后续 AppKit 事件和用户再次点击
-仍可恢复，不能留下“重试次数耗尽后永久卡住”的状态。`NSPopover.isShown` 只表示调用过
-`show`，还必须给动画留出 window 创建宽限期并确认真实 popover window 存在；超时后才关闭
-这次无效展示并重试。macOS 14 及以上使用 cooperative `NSApplication.activate()`，
-macOS 13 仅保留兼容的旧 activation fallback。
+`NSPopover.show`。菜单栏 presenter 必须在状态栏按钮拥有 window 且可见后展开，但不能把
+`NSApplication.isActive` 或 popover window 的 `isKeyWindow` 当作展示前置条件：macOS 14
+及以上的 cooperative `NSApplication.activate()` 可能拒绝 LSUIElement App 的请求，激活与
+`makeKey()` 都只能是展示后的 best-effort 增强。
+
+App 未 active 时，popover 临时使用 `.applicationDefined`，由状态栏按钮、Escape 与全局鼠标
+监听负责关闭；App 获得 active 后再切为 `.transient` 并尝试令真实 window 成为 key。
+SwiftUI 面板显式使用 active control appearance，状态栏按钮以持久 `state` 表示面板已展示；
+状态轮询仅在 indicator 改变时重绘图标，不能抹掉展示状态。流程由
+`applicationDidBecomeActive`、popover delegate 与 common run loop 上短时、有界的退避重试
+推进，不接入高频 `applicationDidUpdate`。`NSPopover.isShown` 只表示调用过 `show`，还必须
+给动画留出 window 创建宽限期并确认真实 window；超时后执行一次非阻塞兜底展示并清除
+pending，不能留下永久卡住状态。macOS 13 仅保留兼容的旧 activation fallback。
 
 Web GUI 总览页的“启动网关”与“停止网关”只导航到 `network` 页面，不得直接调用
 gateway start/stop API。真实生命周期动作留在网络页，使 topology、plan blocker、DHCP

--- a/docs/agent-wiki/wiki/concepts/gui-control-plane.md
+++ b/docs/agent-wiki/wiki/concepts/gui-control-plane.md
@@ -21,8 +21,12 @@ AppKit `NSStatusItem` + `NSPopover` 承载现有 SwiftUI `MenuContentView`。状
 popover window 创建后显式令它成为 key window。后者确保 macOS 26 等较新系统把
 “打开 OpenSurge 面板”的 prominent button 绘制为有焦点的强调色，而不是非活跃窗口样式。
 该流程由 `applicationDidBecomeActive`、`applicationDidUpdate` 与 popover delegate 事件
-推进，不依赖固定延迟；`NSPopover.isShown` 只表示调用过 `show`，还必须确认真实 popover
-window 存在，否则关闭这次无效展示后重试。
+推进，并以 common run loop 上的短时、有界退避重试覆盖 macOS 26 首次启动时状态项挂载或
+activation 事件晚到的情况；重试期限耗尽后不得继续轮询，但后续 AppKit 事件和用户再次点击
+仍可恢复，不能留下“重试次数耗尽后永久卡住”的状态。`NSPopover.isShown` 只表示调用过
+`show`，还必须给动画留出 window 创建宽限期并确认真实 popover window 存在；超时后才关闭
+这次无效展示并重试。macOS 14 及以上使用 cooperative `NSApplication.activate()`，
+macOS 13 仅保留兼容的旧 activation fallback。
 
 Web GUI 总览页的“启动网关”与“停止网关”只导航到 `network` 页面，不得直接调用
 gateway start/stop API。真实生命周期动作留在网络页，使 topology、plan blocker、DHCP

--- a/docs/agent-wiki/wiki/concepts/gui-control-plane.md
+++ b/docs/agent-wiki/wiki/concepts/gui-control-plane.md
@@ -16,6 +16,13 @@ AppKit `NSStatusItem` + `NSPopover` 承载现有 SwiftUI `MenuContentView`。状
 `/Applications/OpenSurge.app` 进入同一个 presenter；后者只确保面板展开，不触发网关
 或 Control Service 生命周期动作。每次菜单栏 App 进程启动完成都会主动展开面板，包括
 通过“登录时显示”启动；Finder/Launchpad 的 reopen 事件同样确保面板展开。
+首次启动时，`NSStatusItem` 的按钮可能尚未附着到可见窗口；此时 AppKit 会忽略
+`NSPopover.show`。菜单栏 presenter 必须在状态栏按钮拥有 window 且可见后再展开，并在
+popover window 创建后显式令它成为 key window。后者确保 macOS 26 等较新系统把
+“打开 OpenSurge 面板”的 prominent button 绘制为有焦点的强调色，而不是非活跃窗口样式。
+该流程由 `applicationDidBecomeActive`、`applicationDidUpdate` 与 popover delegate 事件
+推进，不依赖固定延迟；`NSPopover.isShown` 只表示调用过 `show`，还必须确认真实 popover
+window 存在，否则关闭这次无效展示后重试。
 
 Web GUI 总览页的“启动网关”与“停止网关”只导航到 `network` 页面，不得直接调用
 gateway start/stop API。真实生命周期动作留在网络页，使 topology、plan blocker、DHCP

--- a/docs/gui-architecture.zh-CN.md
+++ b/docs/gui-architecture.zh-CN.md
@@ -33,12 +33,15 @@ AppKit `NSStatusItem` 与锚定的 `NSPopover` 承载，内部继续复用 Swift
 `/Applications/OpenSurge.app` 时，`NSApplicationDelegate` 会要求同一个控制器确保
 面板已经展开。每次菜单栏 App 进程启动完成都会主动展开面板，因此通过“登录时显示”
 启动时也会弹出。首次启动会等待状态栏按钮实际附着到可见窗口后再调用
-`NSPopover.show`；popover window 创建后会成为 key window，使 macOS 26 等较新系统中的
-prominent action 保持有焦点的强调色。展示过程以 App 激活、App 更新与 popover delegate
-事件为主，并以 common run loop 上短时、有界的退避重试覆盖 macOS 26 首启时 activation
-或状态栏按钮挂载事件晚到的情况。它会给 popover 动画留出 window 创建宽限期，不会把
-`NSPopover.isShown` 当成窗口已经真实出现的充分证据；重试期限到达后停止轮询，但后续
-AppKit 事件或用户再次点击仍可重新进入展示流程。
+`NSPopover.show`，但不会等待 App active 或 popover window 成为 key；cooperative
+activation 和 `makeKey()` 都只是展示后的 best-effort 增强。App 未 active 时 popover 使用
+`.applicationDefined` 并自行处理状态栏按钮、Escape 与外部鼠标点击关闭，获得 active 后再
+切回 `.transient`。SwiftUI 面板显式保持 active control appearance，状态栏按钮用持久 state
+记录面板展示状态；状态轮询只有 indicator 改变才重绘图标。展示过程由 App 激活、popover
+delegate 与 common run loop 上短时、有界的退避重试推进，不使用高频
+`applicationDidUpdate`。它会给 popover 动画留出 window 创建宽限期，不把
+`NSPopover.isShown` 当成窗口已经真实出现的充分证据；重试期限到达时执行一次非阻塞兜底并
+清除 pending，后续用户点击仍可重新进入展示流程。
 
 菜单栏提供两个不同的退出层级。“只退出菜单栏 App”在二次确认后直接结束菜单栏进程，
 不会改变用户级 Control Service、网关数据面或 root Helper。“退出 OpenSurge”只有在

--- a/docs/gui-architecture.zh-CN.md
+++ b/docs/gui-architecture.zh-CN.md
@@ -32,7 +32,10 @@ AppKit `NSStatusItem` 与锚定的 `NSPopover` 承载，内部继续复用 Swift
 `MenuContentView`。点击菜单栏图标会切换面板；用户首次主动打开或再次打开
 `/Applications/OpenSurge.app` 时，`NSApplicationDelegate` 会要求同一个控制器确保
 面板已经展开。每次菜单栏 App 进程启动完成都会主动展开面板，因此通过“登录时显示”
-启动时也会弹出。
+启动时也会弹出。首次启动会等待状态栏按钮实际附着到可见窗口后再调用
+`NSPopover.show`；popover window 创建后会成为 key window，使 macOS 26 等较新系统中的
+prominent action 保持有焦点的强调色。展示过程由 App 激活、App 更新与 popover delegate
+事件推进，不依赖固定延迟，也不会把 `NSPopover.isShown` 当成窗口已经真实出现的充分证据。
 
 菜单栏提供两个不同的退出层级。“只退出菜单栏 App”在二次确认后直接结束菜单栏进程，
 不会改变用户级 Control Service、网关数据面或 root Helper。“退出 OpenSurge”只有在

--- a/docs/gui-architecture.zh-CN.md
+++ b/docs/gui-architecture.zh-CN.md
@@ -34,8 +34,11 @@ AppKit `NSStatusItem` 与锚定的 `NSPopover` 承载，内部继续复用 Swift
 面板已经展开。每次菜单栏 App 进程启动完成都会主动展开面板，因此通过“登录时显示”
 启动时也会弹出。首次启动会等待状态栏按钮实际附着到可见窗口后再调用
 `NSPopover.show`；popover window 创建后会成为 key window，使 macOS 26 等较新系统中的
-prominent action 保持有焦点的强调色。展示过程由 App 激活、App 更新与 popover delegate
-事件推进，不依赖固定延迟，也不会把 `NSPopover.isShown` 当成窗口已经真实出现的充分证据。
+prominent action 保持有焦点的强调色。展示过程以 App 激活、App 更新与 popover delegate
+事件为主，并以 common run loop 上短时、有界的退避重试覆盖 macOS 26 首启时 activation
+或状态栏按钮挂载事件晚到的情况。它会给 popover 动画留出 window 创建宽限期，不会把
+`NSPopover.isShown` 当成窗口已经真实出现的充分证据；重试期限到达后停止轮询，但后续
+AppKit 事件或用户再次点击仍可重新进入展示流程。
 
 菜单栏提供两个不同的退出层级。“只退出菜单栏 App”在二次确认后直接结束菜单栏进程，
 不会改变用户级 Control Service、网关数据面或 root Helper。“退出 OpenSurge”只有在

--- a/packaging/pkg-scripts/installed-processes.sh
+++ b/packaging/pkg-scripts/installed-processes.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+opensurge_is_installed_gui_command() {
+  [[ "$#" -eq 2 ]] || return 2
+  local command="$1"
+  local user_home="$2"
+  local control="$user_home/Library/Application Support/OpenSurge/bin/opensurge-control"
+  local app="/Applications/OpenSurge.app/Contents/MacOS/OpenSurgeMenuBar"
+  local legacy_app="/Applications/OpenSurge Menu Bar.app/Contents/MacOS/OpenSurgeMenuBar"
+
+  case "$command" in
+    "$control"|"$control "*|"$app"|"$app "*|"$legacy_app"|"$legacy_app "*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+opensurge_installed_gui_pids() {
+  [[ "$#" -eq 2 ]] || return 2
+  local uid_value="$1"
+  local user_home="$2"
+  local process_name pid command
+
+  for process_name in opensurge-control OpenSurgeMenuBar; do
+    while IFS= read -r pid; do
+      [[ "$pid" =~ ^[0-9]+$ ]] || continue
+      command="$(/bin/ps -ww -p "$pid" -o command= 2>/dev/null || true)"
+      command="${command#"${command%%[![:space:]]*}"}"
+      if opensurge_is_installed_gui_command "$command" "$user_home"; then
+        printf '%s\n' "$pid"
+      fi
+    done < <(/usr/bin/pgrep -u "$uid_value" -x "$process_name" 2>/dev/null || true)
+  done
+}

--- a/packaging/pkg-scripts/preinstall
+++ b/packaging/pkg-scripts/preinstall
@@ -5,6 +5,8 @@ ROOT="/Library/Application Support/OpenSurge"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=packaging/pkg-scripts/recovery-state.sh
 source "$SCRIPT_DIR/recovery-state.sh"
+# shellcheck source=packaging/pkg-scripts/installed-processes.sh
+source "$SCRIPT_DIR/installed-processes.sh"
 CONSOLE_USER="$(stat -f '%Su' /dev/console)"
 [[ "$CONSOLE_USER" != "root" && "$CONSOLE_USER" != "loginwindow" ]] || { echo "OpenSurge upgrade requires a logged-in GUI user" >&2; exit 1; }
 
@@ -28,18 +30,20 @@ fi
 # the payload. The gateway cleanup must use the currently installed CLI and
 # config, so it deliberately runs before the helper is unloaded.
 launchctl bootout "gui/$UID_VALUE/com.opensurge.control" 2>/dev/null || true
-/usr/bin/pkill -TERM -u "$UID_VALUE" -x opensurge-control 2>/dev/null || true
-/usr/bin/pkill -TERM -u "$UID_VALUE" -x OpenSurgeMenuBar 2>/dev/null || true
+GUI_PIDS="$(opensurge_installed_gui_pids "$UID_VALUE" "$USER_HOME")"
+for pid in $GUI_PIDS; do
+  /bin/kill -TERM "$pid" 2>/dev/null || true
+done
 
 for _ in {1..50}; do
-  if ! /usr/bin/pgrep -u "$UID_VALUE" -x opensurge-control >/dev/null 2>&1 && \
-     ! /usr/bin/pgrep -u "$UID_VALUE" -x OpenSurgeMenuBar >/dev/null 2>&1; then
+  GUI_PIDS="$(opensurge_installed_gui_pids "$UID_VALUE" "$USER_HOME")"
+  if [[ -z "$GUI_PIDS" ]]; then
     break
   fi
   sleep 0.1
 done
-if /usr/bin/pgrep -u "$UID_VALUE" -x opensurge-control >/dev/null 2>&1 || \
-   /usr/bin/pgrep -u "$UID_VALUE" -x OpenSurgeMenuBar >/dev/null 2>&1; then
+GUI_PIDS="$(opensurge_installed_gui_pids "$UID_VALUE" "$USER_HOME")"
+if [[ -n "$GUI_PIDS" ]]; then
   echo "OpenSurge GUI processes did not stop; refusing to replace running executables" >&2
   exit 3
 fi

--- a/packaging/unsigned-release-notes.md
+++ b/packaging/unsigned-release-notes.md
@@ -6,10 +6,10 @@
 
 <!-- 发布前请更新为当前版本的主要变化，并同步维护 English / Highlights。 -->
 
-- 菜单栏新增原生“卸载 OpenSurge”流程：网关停止后可通过 macOS 管理员授权移除 App、Control Service 与 root Helper，并选择保留配置数据或彻底删除。
-- 菜单栏 App 改用纯 AppKit 生命周期，避免系统创建或恢复无用的空设置窗口，并提升应用启动与状态面板行为的稳定性。
-- 修复 Issue #7：导入的 mihomo profile 现在兼容 flow/block 风格的 `rules`、策略组与 rule providers，以及带引号键、注释和相对 Provider 路径。
-- 来源预览与实际应用现在复用同一套 YAML 结构验证；无效候选配置会在写入或重载前失败，保持当前网关和已应用配置不变。
+- 菜单栏状态面板不再把 App 激活或 key window 当作显示前置条件；首次启动会等待状态栏锚点真正上屏，并在协作式激活被系统拒绝时仍继续展示。
+- 面板打开期间会自行管理关闭行为，并保持“打开 OpenSurge 面板”按钮与状态栏图标的系统强调状态；快速状态轮询不会再清除选中外观。
+- 修复失败的 `NSPopover` 逻辑状态与重试兜底，避免启动后必须再次点击 App 或状态栏图标才能展开面板。
+- 升级安装器只停止已安装路径中的 OpenSurge App 与 Control Service，不再因仓库或临时目录中的同名开发进程而错误拒绝安装。
 
 ### 选择安装包
 
@@ -57,10 +57,10 @@ OpenSurge 自有代码采用 `GPL-3.0-only`。第三方许可证、声明与准�
 
 ### Highlights
 
-- Added a native Uninstall OpenSurge flow to the menu bar. Once the gateway is stopped, administrator authorization can remove the app, Control Service, and root Helper while either preserving configuration data or deleting everything.
-- Moved the menu bar app to a pure AppKit lifecycle, preventing macOS from creating or restoring an unused empty Settings window and improving launch and panel stability.
-- Fixed Issue #7: imported mihomo profiles now support flow- and block-style `rules`, proxy groups, and rule providers, including quoted keys, comments, and relative provider paths.
-- Source preview and final application now share the same YAML structural validation. Invalid candidates fail before write or reload, leaving the current gateway and applied configuration unchanged.
+- The menu-bar panel no longer treats application activation or key-window status as visibility prerequisites. First launch waits for a real status-item anchor and continues presenting even when cooperative activation is declined.
+- While visible, the panel manages its own dismissal and preserves the system accent appearance of both the primary OpenSurge action and the status item across rapid status polling.
+- Failed logical `NSPopover` states now recover through bounded retries and a final fallback, avoiding the need to click the app or status item again after launch.
+- Installer upgrades now stop only OpenSurge processes from installed paths, so same-name development builds in repositories or temporary directories no longer cause false installation failures.
 
 ### Choose a package
 

--- a/scripts/check-gui-packaging.sh
+++ b/scripts/check-gui-packaging.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PREINSTALL="$ROOT/packaging/pkg-scripts/preinstall"
 POSTINSTALL="$ROOT/packaging/pkg-scripts/postinstall"
 RECOVERY_STATE="$ROOT/packaging/pkg-scripts/recovery-state.sh"
+INSTALLED_PROCESSES="$ROOT/packaging/pkg-scripts/installed-processes.sh"
 RELEASE_DEPS="$ROOT/scripts/prepare-gui-release-deps.sh"
 RELEASE_VERIFY="$ROOT/scripts/verify-unsigned-gui-installer.sh"
 RELEASE_WORKFLOW="$ROOT/.github/workflows/release-unsigned.yml"
@@ -19,7 +20,7 @@ WEB_APP="$ROOT/web/src/App.tsx"
 MENUBAR_CONTENT="$ROOT/apps/menubar/Sources/OpenSurgeMenuBar/MenuContentView.swift"
 UNINSTALLER="$ROOT/scripts/uninstall-gui.sh"
 
-bash -n "$PREINSTALL" "$POSTINSTALL" "$RECOVERY_STATE" "$ROOT/scripts/uninstall-gui.sh" \
+bash -n "$PREINSTALL" "$POSTINSTALL" "$RECOVERY_STATE" "$INSTALLED_PROCESSES" "$ROOT/scripts/uninstall-gui.sh" \
   "$ROOT/scripts/build-gui-installer.sh" "$RELEASE_DEPS" "$RELEASE_VERIFY"
 [[ -x "$PREINSTALL" ]] || { echo "preinstall must be executable" >&2; exit 1; }
 [[ -x "$RELEASE_DEPS" && -x "$RELEASE_VERIFY" ]] || {
@@ -46,6 +47,33 @@ grep -Fq 'source "$SCRIPT_DIR/recovery-state.sh"' "$PREINSTALL" || {
   echo "preinstall must use the shared recovery terminal-state guard" >&2
   exit 1
 }
+grep -Fq 'source "$SCRIPT_DIR/installed-processes.sh"' "$PREINSTALL" || {
+  echo "preinstall must scope GUI process handling to installed executables" >&2
+  exit 1
+}
+# shellcheck source=packaging/pkg-scripts/installed-processes.sh
+source "$INSTALLED_PROCESSES"
+opensurge_is_installed_gui_command \
+  "/Applications/OpenSurge.app/Contents/MacOS/OpenSurgeMenuBar" "/Users/tester" || {
+  echo "current installed menu bar path must be recognized" >&2
+  exit 1
+}
+opensurge_is_installed_gui_command \
+  "/Applications/OpenSurge Menu Bar.app/Contents/MacOS/OpenSurgeMenuBar" "/Users/tester" || {
+  echo "legacy installed menu bar path must be recognized" >&2
+  exit 1
+}
+opensurge_is_installed_gui_command \
+  "/Users/tester/Library/Application Support/OpenSurge/bin/opensurge-control --config /tmp/config.yaml" \
+  "/Users/tester" || {
+  echo "installed per-user control service path must be recognized" >&2
+  exit 1
+}
+if opensurge_is_installed_gui_command \
+  "/Users/tester/project/bin/OpenSurge.app/Contents/MacOS/OpenSurgeMenuBar" "/Users/tester"; then
+  echo "a developer menu bar build must not block package installation" >&2
+  exit 1
+fi
 if grep -Eq 'recovery-state|RECOVERY_STAGE|recovery\.json' "$UNINSTALLER"; then
   echo "uninstall must not be blocked by the DHCP recovery state" >&2
   exit 1
@@ -83,10 +111,14 @@ helper_line="$(line_of 'bootout system/com.opensurge.helper' "$PREINSTALL")"
   exit 1
 }
 
-grep -Fq 'pkill -TERM -u "$UID_VALUE" -x OpenSurgeMenuBar' "$PREINSTALL" || {
-  echo "preinstall must stop the menu bar app" >&2
+grep -Fq 'opensurge_installed_gui_pids "$UID_VALUE" "$USER_HOME"' "$PREINSTALL" || {
+  echo "preinstall must stop installed OpenSurge GUI processes" >&2
   exit 1
 }
+if grep -Eq 'p(kill|grep).*-x (opensurge-control|OpenSurgeMenuBar)' "$PREINSTALL"; then
+  echo "preinstall must not block on unrelated same-name developer processes" >&2
+  exit 1
+fi
 grep -Fq 'rm -rf "/Applications/OpenSurge Menu Bar.app"' "$POSTINSTALL" || {
   echo "postinstall must remove the legacy menu bar app bundle" >&2
   exit 1

--- a/scripts/check-menubar.sh
+++ b/scripts/check-menubar.sh
@@ -80,8 +80,8 @@ grep -Fq 'button?.window?.isVisible == true' "$MENU_BAR_CONTROLLER" || {
   echo "menu bar panel must wait until its status-item anchor is actually visible" >&2
   exit 1
 }
-grep -Fq 'panelWindow?.makeKey()' "$MENU_BAR_CONTROLLER" || {
-  echo "menu bar popover must become key so prominent controls retain focused tint" >&2
+grep -Fq 'panelWindow.makeKey()' "$MENU_BAR_CONTROLLER" || {
+  echo "menu bar popover should request key status after activation" >&2
   exit 1
 }
 grep -Fq 'NSApplication.shared.activate()' "$MENU_BAR_CONTROLLER" || {
@@ -93,7 +93,39 @@ grep -Fq 'activate(ignoringOtherApps: true)' "$MENU_BAR_CONTROLLER" || {
   exit 1
 }
 grep -Fq 'func applicationDidBecomeActive' "$MENU_BAR_CONTROLLER" || {
-  echo "menu bar presentation must resume from AppKit activation events" >&2
+  echo "menu bar presentation must enhance focus from AppKit activation events" >&2
+  exit 1
+}
+if grep -Fq 'func applicationDidUpdate' "$MENU_BAR_CONTROLLER"; then
+  echo "menu bar presentation must not churn retries from every AppKit update event" >&2
+  exit 1
+fi
+if grep -Eq 'guard[[:space:]]+applicationActive|guard[[:space:]]+panelWindowKey' "$MENU_BAR_CONTROLLER"; then
+  echo "application activation and key-window status must not block popover visibility" >&2
+  exit 1
+fi
+grep -Fq 'candidate.behavior = .applicationDefined' "$MENU_BAR_CONTROLLER" || {
+  echo "an inactive menu bar app must retain responsibility for its visible popover" >&2
+  exit 1
+}
+grep -Fq 'NSEvent.addGlobalMonitorForEvents' "$MENU_BAR_CONTROLLER" || {
+  echo "application-defined popovers must close on outside mouse interaction" >&2
+  exit 1
+}
+grep -Fq 'button.state = panelPresented ? .on : .off' "$MENU_BAR_CONTROLLER" || {
+  echo "the status item must retain persistent presented state" >&2
+  exit 1
+}
+grep -Fq 'menuBarStatusItemNeedsRefresh(' "$MENU_BAR_CONTROLLER" || {
+  echo "status polling must not redraw an unchanged status-item icon" >&2
+  exit 1
+}
+grep -Fq '.environment(\.controlActiveState, .key)' "$MENU_BAR_CONTROLLER" || {
+  echo "the menu panel must retain active control appearance when activation is declined" >&2
+  exit 1
+}
+grep -Fq 'finishTimedOutPanelPresentation()' "$MENU_BAR_CONTROLLER" || {
+  echo "bounded presentation retries must end in a non-pending fallback" >&2
   exit 1
 }
 grep -Fq 'inModes: [.common]' "$MENU_BAR_CONTROLLER" || {

--- a/scripts/check-menubar.sh
+++ b/scripts/check-menubar.sh
@@ -76,10 +76,22 @@ grep -Fq '"/Library/Application Support/OpenSurge/share/uninstall-gui.sh"' "$UNI
 }
 
 MENU_BAR_CONTROLLER="$ROOT/apps/menubar/Sources/OpenSurgeMenuBar/MenuBarController.swift"
-if grep -Fq 'NSApplication.shared.isActive' "$MENU_BAR_CONTROLLER"; then
-  echo "menu bar panel must open for every app launch, including login-item launches" >&2
+grep -Fq 'button?.window?.isVisible == true' "$MENU_BAR_CONTROLLER" || {
+  echo "menu bar panel must wait until its status-item anchor is actually visible" >&2
   exit 1
-fi
+}
+grep -Fq 'panelWindow?.makeKey()' "$MENU_BAR_CONTROLLER" || {
+  echo "menu bar popover must become key so prominent controls retain focused tint" >&2
+  exit 1
+}
+grep -Fq 'activate(ignoringOtherApps: true)' "$MENU_BAR_CONTROLLER" || {
+  echo "explicit OpenSurge panel requests must activate the LSUIElement app" >&2
+  exit 1
+}
+grep -Fq 'func applicationDidBecomeActive' "$MENU_BAR_CONTROLLER" || {
+  echo "menu bar presentation must resume from AppKit activation events" >&2
+  exit 1
+}
 
 APP_ENTRYPOINT="$ROOT/apps/menubar/Sources/OpenSurgeMenuBar/OpenSurgeMenuBarApp.swift"
 if grep -Eq 'Settings[[:space:]]*\{|EmptyView[[:space:]]*\(' "$APP_ENTRYPOINT"; then

--- a/scripts/check-menubar.sh
+++ b/scripts/check-menubar.sh
@@ -116,6 +116,10 @@ grep -Fq 'button.state = panelPresented ? .on : .off' "$MENU_BAR_CONTROLLER" || 
   echo "the status item must retain persistent presented state" >&2
   exit 1
 }
+if grep -Fq 'button.highlight(panelPresented)' "$MENU_BAR_CONTROLLER"; then
+  echo "the status item must not stack momentary highlight over its persistent presented state" >&2
+  exit 1
+fi
 grep -Fq 'menuBarStatusItemNeedsRefresh(' "$MENU_BAR_CONTROLLER" || {
   echo "status polling must not redraw an unchanged status-item icon" >&2
   exit 1

--- a/scripts/check-menubar.sh
+++ b/scripts/check-menubar.sh
@@ -84,14 +84,26 @@ grep -Fq 'panelWindow?.makeKey()' "$MENU_BAR_CONTROLLER" || {
   echo "menu bar popover must become key so prominent controls retain focused tint" >&2
   exit 1
 }
+grep -Fq 'NSApplication.shared.activate()' "$MENU_BAR_CONTROLLER" || {
+  echo "macOS 14 and newer must use cooperative application activation" >&2
+  exit 1
+}
 grep -Fq 'activate(ignoringOtherApps: true)' "$MENU_BAR_CONTROLLER" || {
-  echo "explicit OpenSurge panel requests must activate the LSUIElement app" >&2
+  echo "macOS 13 must retain its compatible application activation fallback" >&2
   exit 1
 }
 grep -Fq 'func applicationDidBecomeActive' "$MENU_BAR_CONTROLLER" || {
   echo "menu bar presentation must resume from AppKit activation events" >&2
   exit 1
 }
+grep -Fq 'inModes: [.common]' "$MENU_BAR_CONTROLLER" || {
+  echo "menu bar presentation fallback must run in common run-loop modes" >&2
+  exit 1
+}
+if grep -Fq 'failedPopoverRecoveryCount' "$MENU_BAR_CONTROLLER"; then
+  echo "menu bar popover recovery must not become permanently exhausted" >&2
+  exit 1
+fi
 
 APP_ENTRYPOINT="$ROOT/apps/menubar/Sources/OpenSurgeMenuBar/OpenSurgeMenuBarApp.swift"
 if grep -Eq 'Settings[[:space:]]*\{|EmptyView[[:space:]]*\(' "$APP_ENTRYPOINT"; then


### PR DESCRIPTION
## Summary

- wait for a genuinely attached status-item anchor before showing the first-launch popover
- never gate popover visibility on application activation or key-window status
- use application-defined dismissal while cooperative activation is unavailable, then return to transient behavior after activation
- replace logical `isShown` states that never create a real window
- keep status-item selection and SwiftUI prominent-control appearance persistent across polling updates
- add bounded retry/fallback coverage without `applicationDidUpdate` churn
- prevent unrelated same-name developer processes from blocking package upgrades

## Root cause

`NSPopover.show` does nothing when its positioning view is not visible, while `NSPopover.isShown` becomes true as soon as `show` is invoked. The previous startup path could therefore believe the panel was open when no popover window existed.

An earlier version of this PR incorrectly promoted `NSApplication.isActive` and the popover window's `isKeyWindow` to hard state-machine gates. Cooperative activation can be declined for an `LSUIElement` app, especially during background or login launch, so the panel could remain blocked even after its anchor became usable.

The status-item highlight also used only transient `highlight(_:)`; rapid status polling repeatedly reassigned the icon and could erase the presented appearance. Stacking that momentary highlight on top of a persistent `.on` state is redundant and may be rendered more strongly by a future AppKit implementation.

The installer preflight previously stopped and waited for every process named `OpenSurgeMenuBar` or `opensurge-control`. A stuck local development build therefore caused `preinstall` to reject an otherwise valid upgrade even though Installer was not replacing that executable.

## Fix

- Anchor readiness is the only precondition for calling `show`.
- Activation is requested best-effort but never blocks visibility; `makeKey()` is attempted only after the app actually becomes active.
- An inactive popover uses `.applicationDefined`, with status-item toggle, Escape, and global mouse monitoring responsible for dismissal. It changes to `.transient` after activation.
- The SwiftUI panel receives active control appearance so its prominent action does not become gray when activation is declined.
- The status button uses only persistent `state`; it does not stack momentary `highlight(_:)`, and unchanged indicators are not redrawn during polling.
- A one-second window-creation grace interval distinguishes normal animation from failed presentation.
- Failed logical popovers are replaced rather than relying on a close delegate callback that might never arrive.
- The bounded retry expiry performs one final non-blocking show, verifies it once, and clears pending state on failure.
- `applicationDidUpdate` is no longer connected to presentation, avoiding retry cancellation and repeated focus requests on every event.
- Package preflight now identifies GUI processes by their installed executable paths. `/Applications` and the installed per-user Control Service remain protected, while repository and temporary builds no longer produce false upgrade failures.

## Validation

- `GOCACHE=/private/tmp/opensurge-go-build-cache make gui-test`
  - Go tests passed
  - Web tests passed: 69/69
  - menu-bar state/behavior checks passed
  - GUI packaging checks passed
- the production Swift executable compiled successfully with the repository's macOS 13 deployment target
- macOS 14.8.5 background cold-start smoke via `open -g -n` showed the latest local build's popover automatically
- the primary action stayed blue after more than one rapid-polling interval
- a same-host/same-build A/B comparison found no visible benefit from stacking `highlight(_:)`; the state-only build retained the same standard selected appearance after rapid polling
- the repaired process filter ignored the reproduced stuck repository build while still recognizing current/legacy installed App paths and the installed per-user Control Service path

The available host is macOS 14.8.5, so macOS 26 still requires final clean-install/cold-start confirmation. Apple’s current macOS 26 release notes do not list a specific `NSStatusItem`/`NSPopover` workaround; this change follows the documented weakest guarantees of popover visibility and cooperative activation instead.
