### PR TITLE
fix(dns): run dnsmasq in production foreground mode

### DIFF
--- a/docs/agent-wiki/wiki/concepts/gateway-lifecycle.md
+++ b/docs/agent-wiki/wiki/concepts/gateway-lifecycle.md
@@ -15,6 +15,10 @@ OpenSurge for Mac 会把宿主 Mac 变成下游 LAN gateway。当前 runtime pat
 - 启用下游 IPv6 接管时，BPF broker 和 IPv6 gateway alias 纳入同一个
   runtime/rollback 所有权；自动拓扑还拥有 dnsmasq RA/SLAAC，手工旁路由不发布 RA。
 
+dnsmasq 由 OpenSurge 直接监管，必须使用 `--keep-in-foreground` 运行。不要使用
+`--no-daemon`：后者是 dnsmasq 的调试模式，并会禁用为 TCP DNS 查询 fork 子进程；
+局域网客户端的并发或长连接 TCP/53 查询因此可能阻塞整个 DNS 前端。
+
 ## 下游 LAN 网段
 
 下游网段由 `gateway.lan_ip` 与 `gateway.lan_prefix_len` 共同决定，`internal/lan`

--- a/internal/dhcp/dnsmasq.go
+++ b/internal/dhcp/dnsmasq.go
@@ -46,7 +46,7 @@ func (m Manager) Start() (int, error) {
 	if err := os.WriteFile(m.paths.DNSMasqLog, nil, 0o640); err != nil {
 		return 0, err
 	}
-	pid, err := process.StartDetachedWithLog(m.paths.DNSMasqLog, binary, "--no-daemon", "--log-facility=-", "--conf-file="+m.paths.DNSMasqConf)
+	pid, err := process.StartDetachedWithLog(m.paths.DNSMasqLog, binary, dnsmasqArgs(m.paths.DNSMasqConf)...)
 	if err != nil {
 		return 0, err
 	}
@@ -55,6 +55,10 @@ func (m Manager) Start() (int, error) {
 		return 0, err
 	}
 	return pid, nil
+}
+
+func dnsmasqArgs(configPath string) []string {
+	return []string{"--keep-in-foreground", "--log-facility=-", "--conf-file=" + configPath}
 }
 
 func (m Manager) Check() error {

--- a/internal/dhcp/dnsmasq_test.go
+++ b/internal/dhcp/dnsmasq_test.go
@@ -1,0 +1,14 @@
+package dhcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDNSMasqArgsUseProductionForegroundMode(t *testing.T) {
+	got := dnsmasqArgs("/tmp/dnsmasq.conf")
+	want := []string{"--keep-in-foreground", "--log-facility=-", "--conf-file=/tmp/dnsmasq.conf"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dnsmasqArgs() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- start dnsmasq with `--keep-in-foreground` instead of debug-only `--no-daemon`
- keep stdout/stderr logging and the existing supervised process lifecycle unchanged
- add a regression test for the production startup arguments
- document the foreground-mode lifecycle requirement in the agent wiki

## Rationale

`--no-daemon` is dnsmasq debug mode. The dnsmasq manual states that it does not fork new processes for TCP DNS queries, while `--keep-in-foreground` is intended for launchd and other process supervisors. On a gateway serving LAN clients, concurrent or long-lived TCP/53 connections can therefore delay or block the DNS frontend even though the dnsmasq PID remains alive.

Reference: https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html

## Validation

- `make test`
- bundled dnsmasq 2.93 accepts `--keep-in-foreground` with the generated runtime configuration (`syntax check OK`)
- `git diff --check`

`make lab-test` was not run. This PR does not claim the full host-network DHCP/DNS lifecycle gate.